### PR TITLE
Add deploy_options to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,3 +40,5 @@ inputs:
     default: false
   launch_options:
     description: Additional options to pass to the Fly launch command at creation
+  deploy_options:
+    description: Additional options to pass to the Fly deploy command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,9 +56,9 @@ fi
 # Trigger the deploy of the new version.
 echo "Contents of config $config file: " && cat "$config"
 if [ -n "$INPUT_VM" ]; then
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE" $INPUT_DEPLOY_OPTIONS
 else
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY" $INPUT_DEPLOY_OPTIONS
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
This is needed to inject build secrets. See https://github.com/7Sage/phoenix/pull/3310 for more details.

We should also contribute this back to upstream.